### PR TITLE
getGrcConf: deprecate & get service ns by config

### DIFF
--- a/wrk-api.js
+++ b/wrk-api.js
@@ -18,10 +18,29 @@ class WrkApi extends Base {
   }
 
   getGrcConf () {
+    console.warn('[WARNING] this.getGrcConf is deprecated and gets removed soon')
+    console.warn('[WARNING] set service names in your service config')
+    console.warn('[WARNING] see https://github.com/bitfinexcom/bfx-util-net-js/pull/3 for an example')
+
     return {
       svc_port: this.ctx.apiPort || 0,
-      services: []
+      services: this.getServices()
     }
+  }
+
+  getServices () {
+    const group = this.group
+    const conf = this.conf[group]
+
+    if (conf && conf.services) {
+      return conf.services
+    }
+
+    if (conf && Array.isArray(conf.services)) {
+      return conf.services
+    }
+
+    return []
   }
 
   getApiConf () {


### PR DESCRIPTION
announced services are loaded via config now, removing the
requirement for the services to extend `getGrcConf`.

example: bitfinexcom/bfx-util-net-js#3