### PR TITLE
api: check argument count

### DIFF
--- a/api/base.js
+++ b/api/base.js
@@ -56,8 +56,14 @@ class Api {
       cb(_.isError(err) ? new Error(`ERR_API_BASE: ${err.message}`) : err, res)
     })
 
+    const method = this[action]
+    const argCount = method.length
+    if (args.length !== argCount) {
+      return cb(new Error(`ERR_API_BASE: WRONG ARG COUNT`))
+    }
+
     try {
-      this[action].apply(this, args)
+      method.apply(this, args)
     } catch (e) {
       isExecuted = true
       console.error(e)


### PR DESCRIPTION
as replacement for the broken cb checks in each api function:

```js
if (!_.isFunction(cb)) return cb(new Error('ERR_API_CB_INVALID'))
```

---

note: 

```js
const method = this[action]
```

is a micro optimization, but still a bit faster and handy as we use it multiple times