### PR TITLE
 grenache: automatically infer path for loc.api 

### DIFF
--- a/api/base.js
+++ b/api/base.js
@@ -78,9 +78,9 @@ class Api {
 
   auth (auth, action, args) {
     if (!auth) {
-      return false 
+      return false
     }
-    
+
     this.loadAcl()
 
     const valid = this.checkAcl(auth.fingerprint, action, args)
@@ -96,7 +96,7 @@ class Api {
     if (!this.ctx) {
       this.ctx = this.caller.getCtx()
     }
-   
+
     if (!this.isCtxReady()) {
       return cb(new Error('ERR_API_READY'))
     }

--- a/wrk-api.js
+++ b/wrk-api.js
@@ -2,6 +2,7 @@
 
 const async = require('async')
 const Base = require('bfx-wrk-base')
+const path = require('path')
 
 class WrkApi extends Base {
   init () {
@@ -36,8 +37,14 @@ class WrkApi extends Base {
   }
 
   getApiConf () {
+    const wrk = path.basename(this.ctx.worker, '.js')
+    const tmp = wrk.split('.')
+    tmp.pop()
+    tmp.shift()
+
+    const inferred = tmp.join('.')
     return {
-      path: null
+      path: inferred
     }
   }
 


### PR DESCRIPTION
in 99.9% the main worker spawns a api-wrk in our common naming
schema, so we can infer the file name for the api-wrk.

in other cases, we will print a nice error message. in these
cases devs have to extend `getApiConf` like before.

related:

bitfinexcom/bfx-svc-boot-js#5
bitfinexcom/bfx-facs-api#3