### PR TITLE
grc-fac: set startup prio 2

### DIFF
--- a/wrk-api.js
+++ b/wrk-api.js
@@ -11,7 +11,7 @@ class WrkApi extends Base {
     this.setInitFacs([
       ['fac', 'bfx-facs-grc', 'p0', 'bfx', () => {
         return this.getGrcConf()
-      }],
+      }, 2],
       ['fac', 'bfx-facs-api', 'bfx', 'bfx', () => {
         return this.getApiConf()
       }]


### PR DESCRIPTION
this starts the grc fac with a default prio of 2 to avoid that
a booting service announces too early