### PR TITLE
Add async functions support

### DIFF
--- a/api/base.js
+++ b/api/base.js
@@ -157,12 +157,20 @@ class Api {
         return
       }
       cb(_.isError(err) ? new Error(`ERR_API_BASE: ${err.message}`) : err, res)
+
+      isExecuted = true
     })
 
     const method = this[action]
 
     try {
-      method.apply(this, args)
+      const promise = method.apply(this, args)
+
+      if (promise instanceof Promise) {
+        promise
+          .then(res => args[args.length - 1](null, res))
+          .catch(err => args[args.length - 1](err))
+      }
     } catch (e) {
       isExecuted = true
       console.error(e)


### PR DESCRIPTION
This adds async functions support  to get free of the callback and just return the result, and callback support is remained

For example:
instead
```
  async enableScheduler (space, args, cb) {
    try {
      await this.dao.checkAuthInDb(args)
      await this.dao.updateStateOf('scheduler', true)
      const res = await this.syncNow()

      if (!cb) return res
      cb(null, res)
    } catch (err) {
      if (!cb) throw err
      cb(err)
    }
  }
```
to do this
```
  async enableScheduler (space, args) {
    await this.dao.checkAuthInDb(args)
    await this.dao.updateStateOf('scheduler', true)
    const res = await this.syncNow()

    return res
  }
```