### PR TITLE
Bugfix - Api terminates on empty msg param in request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+package-lock.json

--- a/api/base.js
+++ b/api/base.js
@@ -134,7 +134,7 @@ class Api {
       return cb(new Error('ERR_API_READY'))
     }
 
-    const action = msg.action
+    const action = _.isObject(msg) && _.isString(msg.action) ? msg.action : null
     if (!action || _.startsWith(action, '_') || !this[action]) {
       return cb(new Error('ERR_API_ACTION_NOTFOUND'))
     }

--- a/api/base.js
+++ b/api/base.js
@@ -134,7 +134,7 @@ class Api {
       return cb(new Error('ERR_API_READY'))
     }
 
-    const action = _.isObject(msg) && _.isString(msg.action) ? msg.action : null
+    const { action } = msg || {}
     if (!action || _.startsWith(action, '_') || !this[action]) {
       return cb(new Error('ERR_API_ACTION_NOTFOUND'))
     }

--- a/api/base.js
+++ b/api/base.js
@@ -15,7 +15,7 @@ class Api {
 
   _space (service, msg) {
     return {
-      service: service,
+      service,
       svp: service.split(':')
     }
   }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,17 @@
     }
   ],
   "devDependencies": {
-    "mocha": "^5.2.0",
-    "standard": "^12.0.1"
+    "mocha": "^8.1.3",
+    "standard": "^14.3.4"
+  },
+  "standard": {
+    "globals": [
+      "it",
+      "describe",
+      "before",
+      "after",
+      "beforeEach",
+      "afterEach"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,17 +9,19 @@
   },
   "main": "index.js",
   "scripts": {
-    "test": "standard && mocha"
+    "lint": "standard",
+    "lint:fix": "standard --fix",
+    "test": "npm run lint && mocha"
   },
   "keywords": [
     "bitfinex"
   ],
   "dependencies": {
-    "async": "^2.6.1",
+    "async": "^3.2.4",
     "bfx-facs-api": "git+https://github.com/bitfinexcom/bfx-facs-api.git",
     "bfx-facs-grc": "git+https://github.com/bitfinexcom/bfx-facs-grc.git",
     "bfx-wrk-base": "git+https://github.com/bitfinexcom/bfx-wrk-base.git",
-    "lodash": "^4.17.10"
+    "lodash": "^4.17.21"
   },
   "engine": {
     "node": ">=8.0"
@@ -36,17 +38,7 @@
     }
   ],
   "devDependencies": {
-    "mocha": "^8.1.3",
-    "standard": "^14.3.4"
-  },
-  "standard": {
-    "globals": [
-      "it",
-      "describe",
-      "before",
-      "after",
-      "beforeEach",
-      "afterEach"
-    ]
+    "mocha": "^10.2.0",
+    "standard": "^17.1.0"
   }
 }

--- a/test/promises.js
+++ b/test/promises.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { Api } = require('..')
+const _ = require('lodash')
 const assert = require('assert')
 
 class ServiceApi extends Api {
@@ -11,8 +12,8 @@ class ServiceApi extends Api {
   }
 
   twoCallbacks (space, ip, cb) {
-    cb(null, 'a')
-    cb(null, 'b')
+    cb(null, ip)
+    cb(null, ip)
   }
 }
 
@@ -26,11 +27,11 @@ describe('callback handling', () => {
   it('handles callbacks', (done) => {
     api.handle('test', {
       action: 'asyncCb',
-      args: [ '53.1.34.21' ]
+      args: ['53.1.34.21']
     }, (err, res) => {
       if (err) throw err
 
-      assert.equal(res, '53.1.34.21')
+      assert.strictEqual(res, '53.1.34.21')
       done()
     })
   })
@@ -38,11 +39,20 @@ describe('callback handling', () => {
   it('errors if callback called twice', (done) => {
     api.handle('test', {
       action: 'twoCallbacks',
-      args: [ '53.1.34.21' ]
+      args: ['53.1.34.21']
     }, (err, res) => {
       if (err) throw err
 
-      assert.equal(res, '53.1.34.21')
+      assert.strictEqual(res, '53.1.34.21')
+      done()
+    })
+  })
+
+  it('it should handle empty msg', (done) => {
+    api.handle('test', null, (err, res) => {
+      assert.strictEqual(_.isNil(res), true)
+      assert.strictEqual(err instanceof Error, true)
+      assert.strictEqual(err.message, 'ERR_API_ACTION_NOTFOUND')
       done()
     })
   })

--- a/test/promises.js
+++ b/test/promises.js
@@ -1,5 +1,7 @@
 'use strict'
 
+/* eslint-env mocha */
+
 const { Api } = require('..')
 const _ = require('lodash')
 const assert = require('assert')

--- a/wrk-api.js
+++ b/wrk-api.js
@@ -63,7 +63,7 @@ class WrkApi extends Base {
   }
 
   _start (cb) {
-    async.series([ next => { super._start(next) },
+    async.series([next => { super._start(next) },
       next => {
         if (this.api_bfx) {
           this.grc_bfx.set('api', this.api_bfx.api)


### PR DESCRIPTION
After api running a while sometimes it retrieves a request without msg param and in this case it terminates since the handler doesn't expect this behavior. Example of log trace:
```
*****/node_modules/bfx-wrk-api/api/base.js:137
    const action = msg.action
                       ^

TypeError: Cannot read property 'action' of undefined
    at MyApi.handle (*****/node_modules/bfx-wrk-api/api/base.js:137:24)
    at Grc.onRequest (*****/node_modules/bfx-facs-grc/index.js:72:11)
    at TransportRPCServer.emit (events.js:310:20)
    at TransportRPCServer.handleRequest (*****/node_modules/grenache-nodejs-http/lib/TransportRPCServer.js:130:10)
    at IncomingMessage.<anonymous> (*****/node_modules/grenache-nodejs-http/lib/TransportRPCServer.js:93:12)
    at IncomingMessage.emit (events.js:322:22)
    at endReadableNT (_stream_readable.js:1187:12)
    at processTicksAndRejections (internal/process/task_queues.js:84:21)
````

This PR adds a small fix for this issue and also updates test cases and also updates dev packages which had security issues (minimalist issue in mocha). 